### PR TITLE
fix: update workflow to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Workflow image `ubuntu-18.04` doesn't exist anymore, so no workflows run. This blocks PRs, e.g. #15.
